### PR TITLE
Prevent monitors from going to fractional coordinates

### DIFF
--- a/packages/scratch-gui/src/components/monitor/monitor.jsx
+++ b/packages/scratch-gui/src/components/monitor/monitor.jsx
@@ -53,6 +53,7 @@ const MonitorComponent = props => (
             disabled={!props.draggable}
             onStop={props.onDragEnd}
             scale={props.scale}
+            grid={[1*props.scale,1*props.scale]} // Prevent going to fractional coordinates
         >
             <Box
                 className={styles.monitorContainer}

--- a/packages/scratch-gui/src/containers/monitor.jsx
+++ b/packages/scratch-gui/src/containers/monitor.jsx
@@ -104,8 +104,8 @@ class Monitor extends React.Component {
         this.props.removeMonitorRect(this.props.id);
     }
     handleDragEnd (e, {x, y}) {
-        const newX = parseInt(this.element.style.left, 10) + x;
-        const newY = parseInt(this.element.style.top, 10) + y;
+        const newX = parseInt(this.element.style.left, 10) + Math.round(x);
+        const newY = parseInt(this.element.style.top, 10) + Math.round(y);
         this.props.onDragEnd(
             this.props.id,
             newX,


### PR DESCRIPTION
### Proposed Changes

Add `grid=[scale, scale]` to the `<Draggable>` to make it round the coordinates while dragging
Add rounding in the drag event to prevent floating point errors

### Reason for Changes

The existing code expects monitors to be at integer coordinates